### PR TITLE
Refactor SourceLocationTest to `using namespace`

### DIFF
--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -1518,6 +1518,8 @@ struct DeclaratorChunk {
   struct MemberPointerTypeInfo {
     /// The type qualifiers: const/volatile/restrict/__unaligned/_Atomic.
     unsigned TypeQuals : 5;
+    /// Location of the '*' token.
+    unsigned StarLoc;
     // CXXScopeSpec has a constructor, so it can't be a direct member.
     // So we need some pointer-aligned storage and a bit of trickery.
     alignas(CXXScopeSpec) char ScopeMem[sizeof(CXXScopeSpec)];
@@ -1660,11 +1662,13 @@ struct DeclaratorChunk {
 
   static DeclaratorChunk getMemberPointer(const CXXScopeSpec &SS,
                                           unsigned TypeQuals,
-                                          SourceLocation Loc) {
+                                          SourceLocation StarLoc,
+                                          SourceLocation EndLoc) {
     DeclaratorChunk I;
     I.Kind          = MemberPointer;
     I.Loc           = SS.getBeginLoc();
-    I.EndLoc        = Loc;
+    I.EndLoc = EndLoc;
+    I.Mem.StarLoc = StarLoc.getRawEncoding();
     I.Mem.TypeQuals = TypeQuals;
     new (I.Mem.ScopeMem) CXXScopeSpec(SS);
     return I;

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -5643,8 +5643,8 @@ void Parser::ParseDeclaratorInternal(Declarator &D,
         return;
       }
 
-      SourceLocation Loc = ConsumeToken();
-      D.SetRangeEnd(Loc);
+      SourceLocation StarLoc = ConsumeToken();
+      D.SetRangeEnd(StarLoc);
       DeclSpec DS(AttrFactory);
       ParseTypeQualifierListOpt(DS);
       D.ExtendWithDeclSpec(DS);
@@ -5655,7 +5655,7 @@ void Parser::ParseDeclaratorInternal(Declarator &D,
       // Sema will have to catch (syntactically invalid) pointers into global
       // scope. It has to catch pointers into namespace scope anyway.
       D.AddTypeInfo(DeclaratorChunk::getMemberPointer(
-                        SS, DS.getTypeQualifiers(), DS.getEndLoc()),
+                        SS, DS.getTypeQualifiers(), StarLoc, DS.getEndLoc()),
                     std::move(DS.getAttributes()),
                     /* Don't replace range end. */ SourceLocation());
       return;

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -5840,7 +5840,7 @@ namespace {
       }
 
       // Finally fill in MemberPointerLocInfo fields.
-      TL.setStarLoc(Chunk.Loc);
+      TL.setStarLoc(SourceLocation::getFromRawEncoding(Chunk.Mem.StarLoc));
       TL.setClassTInfo(ClsTInfo);
     }
     void VisitLValueReferenceTypeLoc(LValueReferenceTypeLoc TL) {

--- a/clang/unittests/AST/CMakeLists.txt
+++ b/clang/unittests/AST/CMakeLists.txt
@@ -42,4 +42,5 @@ clang_target_link_libraries(ASTTests
   clangFrontend
   clangSerialization
   clangTooling
+  LLVMTestingSupport
   )

--- a/clang/unittests/AST/DeclTest.cpp
+++ b/clang/unittests/AST/DeclTest.cpp
@@ -13,6 +13,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Mangle.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Tooling/Tooling.h"
@@ -77,14 +78,9 @@ TEST(Decl, AsmLabelAttr) {
   assert(Ctx.getTargetInfo().getDataLayout().getGlobalPrefix() &&
          "Expected target to have a global prefix");
   DiagnosticsEngine &Diags = AST->getDiagnostics();
-  SourceManager &SM = AST->getSourceManager();
-  FileID MainFileID = SM.getMainFileID();
 
-  // Find the method decls within the AST.
-  SmallVector<Decl *, 1> Decls;
-  AST->findFileRegionDecls(MainFileID, Code.find('{'), 0, Decls);
-  ASSERT_TRUE(Decls.size() == 1);
-  CXXRecordDecl *DeclS = cast<CXXRecordDecl>(Decls[0]);
+  auto *DeclS =
+      selectFirst<CXXRecordDecl>("d", match(cxxRecordDecl().bind("d"), Ctx));
   NamedDecl *DeclF = *DeclS->method_begin();
   NamedDecl *DeclG = *(++DeclS->method_begin());
 

--- a/clang/unittests/AST/DeclTest.cpp
+++ b/clang/unittests/AST/DeclTest.cpp
@@ -13,7 +13,6 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Mangle.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
-#include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Tooling/Tooling.h"
@@ -78,9 +77,14 @@ TEST(Decl, AsmLabelAttr) {
   assert(Ctx.getTargetInfo().getDataLayout().getGlobalPrefix() &&
          "Expected target to have a global prefix");
   DiagnosticsEngine &Diags = AST->getDiagnostics();
+  SourceManager &SM = AST->getSourceManager();
+  FileID MainFileID = SM.getMainFileID();
 
-  auto *DeclS =
-      selectFirst<CXXRecordDecl>("d", match(cxxRecordDecl().bind("d"), Ctx));
+  // Find the method decls within the AST.
+  SmallVector<Decl *, 1> Decls;
+  AST->findFileRegionDecls(MainFileID, Code.find('{'), 0, Decls);
+  ASSERT_TRUE(Decls.size() == 1);
+  CXXRecordDecl *DeclS = cast<CXXRecordDecl>(Decls[0]);
   NamedDecl *DeclF = *DeclS->method_begin();
   NamedDecl *DeclG = *(++DeclS->method_begin());
 

--- a/clang/unittests/AST/SourceLocationTest.cpp
+++ b/clang/unittests/AST/SourceLocationTest.cpp
@@ -15,11 +15,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "clang/AST/ASTContext.h"
 #include "MatchVerifier.h"
+#include "clang/AST/ASTContext.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Tooling/Tooling.h"
+#include "llvm/Testing/Support/Annotations.h"
 #include "gtest/gtest.h"
 
 using namespace clang;
@@ -838,6 +839,24 @@ TEST(FunctionDecl, ExceptionSpecifications) {
                               parmVarDecl(hasType(pointerType(pointee(
                                   parenType(innerType(functionType())))))),
                               Lang_CXX11));
+}
+
+TEST(Decl, MemberPointerStarLoc) {
+  llvm::Annotations Example(R"cpp(
+    struct X {};
+    int X::$star^* a;
+  )cpp");
+
+  auto AST = tooling::buildASTFromCode(Example.code());
+  SourceManager &SM = AST->getSourceManager();
+  auto &Ctx = AST->getASTContext();
+
+  auto *VD = selectFirst<VarDecl>("vd", match(varDecl().bind("vd"), Ctx));
+  ASSERT_TRUE(VD != nullptr);
+
+  auto TL =
+      VD->getTypeSourceInfo()->getTypeLoc().castAs<MemberPointerTypeLoc>();
+  ASSERT_EQ(SM.getFileOffset(TL.getStarLoc()), Example.point("star"));
 }
 
 } // end namespace

--- a/clang/unittests/AST/SourceLocationTest.cpp
+++ b/clang/unittests/AST/SourceLocationTest.cpp
@@ -22,8 +22,10 @@
 #include "clang/Tooling/Tooling.h"
 #include "gtest/gtest.h"
 
-namespace clang {
-namespace ast_matchers {
+using namespace clang;
+using namespace clang::ast_matchers;
+
+namespace {
 
 // FIXME: Pull the *Verifier tests into their own test file.
 
@@ -642,10 +644,8 @@ TEST(FunctionDecl, FunctionDeclWithThrowSpecification) {
 TEST(FunctionDecl, FunctionDeclWithNoExceptSpecification) {
   RangeVerifier<FunctionDecl> Verifier;
   Verifier.expectRange(1, 1, 1, 24);
-  EXPECT_TRUE(Verifier.match(
-      "void f() noexcept(false);\n",
-      functionDecl(),
-      Language::Lang_CXX11));
+  EXPECT_TRUE(Verifier.match("void f() noexcept(false);\n", functionDecl(),
+                             Lang_CXX11));
 }
 
 class FunctionDeclParametersRangeVerifier : public RangeVerifier<FunctionDecl> {
@@ -767,12 +767,10 @@ TEST(CXXMethodDecl, CXXMethodDeclWithThrowSpecification) {
 TEST(CXXMethodDecl, CXXMethodDeclWithNoExceptSpecification) {
   RangeVerifier<FunctionDecl> Verifier;
   Verifier.expectRange(2, 1, 2, 24);
-  EXPECT_TRUE(Verifier.match(
-      "class A {\n"
-      "void f() noexcept(false);\n"
-      "};\n",
-      functionDecl(),
-      Language::Lang_CXX11));
+  EXPECT_TRUE(Verifier.match("class A {\n"
+                             "void f() noexcept(false);\n"
+                             "};\n",
+                             functionDecl(), Lang_CXX11));
 }
 
 class ExceptionSpecRangeVerifier : public RangeVerifier<TypeLoc> {
@@ -815,19 +813,19 @@ TEST(FunctionDecl, ExceptionSpecifications) {
   std::vector<std::string> Args;
   Args.push_back("-fms-extensions");
   EXPECT_TRUE(Verifier.match("void f() throw(...);\n", loc(functionType()),
-                             Args, Language::Lang_CXX));
+                             Args, Lang_CXX));
 
   Verifier.expectRange(1, 10, 1, 10);
-  EXPECT_TRUE(Verifier.match("void f() noexcept;\n", loc(functionType()),
-                             Language::Lang_CXX11));
+  EXPECT_TRUE(
+      Verifier.match("void f() noexcept;\n", loc(functionType()), Lang_CXX11));
 
   Verifier.expectRange(1, 10, 1, 24);
   EXPECT_TRUE(Verifier.match("void f() noexcept(false);\n", loc(functionType()),
-                             Language::Lang_CXX11));
+                             Lang_CXX11));
 
   Verifier.expectRange(1, 10, 1, 32);
   EXPECT_TRUE(Verifier.match("void f() noexcept(noexcept(1+1));\n",
-                             loc(functionType()), Language::Lang_CXX11));
+                             loc(functionType()), Lang_CXX11));
 
   ParmVarExceptionSpecRangeVerifier Verifier2;
   Verifier2.expectRange(1, 25, 1, 31);
@@ -839,8 +837,8 @@ TEST(FunctionDecl, ExceptionSpecifications) {
   EXPECT_TRUE(Verifier2.match("void g(void (*fp)(void) noexcept(true));\n",
                               parmVarDecl(hasType(pointerType(pointee(
                                   parenType(innerType(functionType())))))),
-                              Language::Lang_CXX11));
+                              Lang_CXX11));
 }
 
-} // end namespace ast_matchers
-} // end namespace clang
+
+} // end namespace

--- a/clang/unittests/AST/SourceLocationTest.cpp
+++ b/clang/unittests/AST/SourceLocationTest.cpp
@@ -840,5 +840,4 @@ TEST(FunctionDecl, ExceptionSpecifications) {
                               Lang_CXX11));
 }
 
-
 } // end namespace


### PR DESCRIPTION
Only for the readability reasons.