### PR TITLE
D76128: [AST] Correct the CXXOperatorCallExpr source range.

### DIFF
--- a/clang-tools-extra/clangd/unittests/SelectionTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SelectionTests.cpp
@@ -380,6 +380,14 @@ TEST(SelectionTest, CommonAncestor) {
       {"struct foo { [[^~foo()]]; };", "CXXDestructorDecl"},
       // FIXME: The following to should be class itself instead.
       {"struct foo { [[fo^o(){}]] };", "CXXConstructorDecl"},
+
+      {R"cpp(
+        struct S1 { void f(); };
+        struct S2 { S1 * operator->(); };
+        void test(S2 s2) {
+          s2[[-^>]]f();
+        }
+      )cpp", "DeclRefExpr"} // DeclRefExpr to the "operator->" method.
   };
   for (const Case &C : Cases) {
     Annotations Test(C.Code);

--- a/clang-tools-extra/clangd/unittests/XRefsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/XRefsTests.cpp
@@ -451,6 +451,14 @@ TEST(LocateSymbol, All) {
         }
       )cpp",
 
+      R"cpp(
+        struct S1 { void f(); };
+        struct S2 { S1 * $decl[[operator]]->(); };
+        void test(S2 s2) {
+          s2-^>f();
+        }
+      )cpp",
+
       R"cpp(// Declaration of explicit template specialization
         template <typename T>
         struct $decl[[Foo]] {};

--- a/clang/lib/AST/ExprCXX.cpp
+++ b/clang/lib/AST/ExprCXX.cpp
@@ -637,7 +637,7 @@ SourceRange CXXOperatorCallExpr::getSourceRangeImpl() const {
       // Postfix operator
       return SourceRange(getArg(0)->getBeginLoc(), getOperatorLoc());
   } else if (Kind == OO_Arrow) {
-    return getArg(0)->getSourceRange();
+    return SourceRange(getArg(0)->getBeginLoc(), getOperatorLoc());
   } else if (Kind == OO_Call) {
     return SourceRange(getArg(0)->getBeginLoc(), getRParenLoc());
   } else if (Kind == OO_Subscript) {


### PR DESCRIPTION
Previously, the range for "->" CXXOperatorCallExpr is the range of the
class object (not including the operator!), e.g. "[[vector_ptr]]->size()".

This patch includes the range of the operator, which fixes the issue
where clangd doesn't go to the overloaded operator "->" definition.

https://reviews.llvm.org/D76128