### PR TITLE
D76124: [TTI] Remove getOperationCost

### DIFF
--- a/llvm/include/llvm/Analysis/TargetTransformInfo.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfo.h
@@ -202,43 +202,14 @@ public:
     TCC_Expensive = 4 ///< The cost of a 'div' instruction on x86.
   };
 
-  /// Estimate the cost of a specific operation when lowered.
-  ///
-  /// Note that this is designed to work on an arbitrary synthetic opcode, and
-  /// thus work for hypothetical queries before an instruction has even been
-  /// formed. However, this does *not* work for GEPs, and must not be called
-  /// for a GEP instruction. Instead, use the dedicated getGEPCost interface as
-  /// analyzing a GEP's cost required more information.
-  ///
-  /// Typically only the result type is required, and the operand type can be
-  /// omitted. However, if the opcode is one of the cast instructions, the
-  /// operand type is required.
-  ///
-  /// The returned cost is defined in terms of \c TargetCostConstants, see its
-  /// comments for a detailed explanation of the cost values.
-  int getOperationCost(unsigned Opcode, Type *Ty, Type *OpTy = nullptr) const;
-
   /// Estimate the cost of a GEP operation when lowered.
-  ///
-  /// The contract for this function is the same as \c getOperationCost except
-  /// that it supports an interface that provides extra information specific to
-  /// the GEP operation.
   int getGEPCost(Type *PointeeType, const Value *Ptr,
                  ArrayRef<const Value *> Operands) const;
 
   /// Estimate the cost of a EXT operation when lowered.
-  ///
-  /// The contract for this function is the same as \c getOperationCost except
-  /// that it supports an interface that provides extra information specific to
-  /// the EXT operation.
   int getExtCost(const Instruction *I, const Value *Src) const;
 
   /// Estimate the cost of a function call when lowered.
-  ///
-  /// The contract for this is the same as \c getOperationCost except that it
-  /// supports an interface that provides extra information specific to call
-  /// instructions.
-  ///
   /// This is the most basic query for estimating call cost: it only knows the
   /// function type and (potentially) the number of arguments at the call site.
   /// The latter is only interesting for varargs function types.
@@ -307,9 +278,9 @@ public:
   /// Estimate the cost of a given IR user when lowered.
   ///
   /// This can estimate the cost of either a ConstantExpr or Instruction when
-  /// lowered. It has two primary advantages over the \c getOperationCost and
-  /// \c getGEPCost above, and one significant disadvantage: it can only be
-  /// used when the IR construct has already been formed.
+  /// lowered. It has two primary advantages over the \c getGEPCost above,
+  /// and one significant disadvantage: it can only be used when the IR
+  /// construct has already been formed.
   ///
   /// The advantages are that it can inspect the SSA use graph to reason more
   /// accurately about the cost. For example, all-constant-GEPs can often be
@@ -1190,7 +1161,6 @@ class TargetTransformInfo::Concept {
 public:
   virtual ~Concept() = 0;
   virtual const DataLayout &getDataLayout() const = 0;
-  virtual int getOperationCost(unsigned Opcode, Type *Ty, Type *OpTy) = 0;
   virtual int getGEPCost(Type *PointeeType, const Value *Ptr,
                          ArrayRef<const Value *> Operands) = 0;
   virtual int getExtCost(const Instruction *I, const Value *Src) = 0;
@@ -1428,9 +1398,6 @@ public:
     return Impl.getDataLayout();
   }
 
-  int getOperationCost(unsigned Opcode, Type *Ty, Type *OpTy) override {
-    return Impl.getOperationCost(Opcode, Ty, OpTy);
-  }
   int getGEPCost(Type *PointeeType, const Value *Ptr,
                  ArrayRef<const Value *> Operands) override {
     return Impl.getGEPCost(PointeeType, Ptr, Operands);

--- a/llvm/include/llvm/CodeGen/BasicTTIImpl.h
+++ b/llvm/include/llvm/CodeGen/BasicTTIImpl.h
@@ -413,29 +413,6 @@ public:
     return TargetTransformInfo::TCC_Expensive;
   }
 
-  unsigned getOperationCost(unsigned Opcode, Type *Ty, Type *OpTy) {
-    const TargetLoweringBase *TLI = getTLI();
-    switch (Opcode) {
-    default: break;
-    case Instruction::Trunc:
-      if (TLI->isTruncateFree(OpTy, Ty))
-        return TargetTransformInfo::TCC_Free;
-      return TargetTransformInfo::TCC_Basic;
-    case Instruction::ZExt:
-      if (TLI->isZExtFree(OpTy, Ty))
-        return TargetTransformInfo::TCC_Free;
-      return TargetTransformInfo::TCC_Basic;
-
-    case Instruction::AddrSpaceCast:
-      if (TLI->isFreeAddrSpaceCast(OpTy->getPointerAddressSpace(),
-                                   Ty->getPointerAddressSpace()))
-        return TargetTransformInfo::TCC_Free;
-      return TargetTransformInfo::TCC_Basic;
-    }
-
-    return BaseT::getOperationCost(Opcode, Ty, OpTy);
-  }
-
   unsigned getInliningThresholdMultiplier() { return 1; }
 
   int getInlinerVectorBonusPercent() { return 150; }

--- a/llvm/lib/Analysis/TargetTransformInfo.cpp
+++ b/llvm/lib/Analysis/TargetTransformInfo.cpp
@@ -146,13 +146,6 @@ TargetTransformInfo &TargetTransformInfo::operator=(TargetTransformInfo &&RHS) {
   return *this;
 }
 
-int TargetTransformInfo::getOperationCost(unsigned Opcode, Type *Ty,
-                                          Type *OpTy) const {
-  int Cost = TTIImpl->getOperationCost(Opcode, Ty, OpTy);
-  assert(Cost >= 0 && "TTI should not produce negative costs!");
-  return Cost;
-}
-
 int TargetTransformInfo::getCallCost(FunctionType *FTy, int NumArgs,
                                      const User *U) const {
   int Cost = TTIImpl->getCallCost(FTy, NumArgs, U);

--- a/llvm/test/Analysis/CostModel/SystemZ/ext-of-icmp-cost.ll
+++ b/llvm/test/Analysis/CostModel/SystemZ/ext-of-icmp-cost.ll
@@ -7,7 +7,7 @@
 define i64 @fun1(i64 %v) {
 ; CHECK-LABEL: 'fun1'
 ; CHECK: Cost Model: Found an estimated cost of 1 for instruction:   %cmp = icmp eq i64 %v, 0
-; CHECK: Cost Model: Found an estimated cost of 1 for instruction:   %z = zext i1 %cmp to i64
+; CHECK: Cost Model: Found an estimated cost of 2 for instruction:   %z = zext i1 %cmp to i64
 ; CHECK: Cost Model: Found an estimated cost of 1 for instruction:   ret i64 %z
   %cmp = icmp eq i64 %v, 0
   %z = zext i1 %cmp to i64
@@ -17,7 +17,7 @@ define i64 @fun1(i64 %v) {
 define i64 @fun2(i64 %v) {
 ; CHECK-LABEL: 'fun2'
 ; CHECK: Cost Model: Found an estimated cost of 1 for instruction:   %cmp = icmp eq i64 %v, 0
-; CHECK: Cost Model: Found an estimated cost of 1 for instruction:   %z = sext i1 %cmp to i64
+; CHECK: Cost Model: Found an estimated cost of 2 for instruction:   %z = sext i1 %cmp to i64
 ; CHECK: Cost Model: Found an estimated cost of 1 for instruction:   ret i64 %z
   %cmp = icmp eq i64 %v, 0
   %z = sext i1 %cmp to i64
@@ -46,7 +46,7 @@ define double @fun4(i64 %v) {
 
 define i64 @fun5(i1 %v) {
 ; CHECK-LABEL: 'fun5'
-; CHECK: Cost Model: Found an estimated cost of 1 for instruction:   %z = zext i1 %v to i64
+; CHECK: Cost Model: Found an estimated cost of 2 for instruction:   %z = zext i1 %v to i64
 ; CHECK: Cost Model: Found an estimated cost of 1 for instruction:   ret i64 %z
   %z = zext i1 %v to i64
   ret i64 %z

--- a/llvm/test/Analysis/CostModel/X86/costmodel.ll
+++ b/llvm/test/Analysis/CostModel/X86/costmodel.ll
@@ -16,7 +16,7 @@ define i64 @foo(i64 %arg) {
 ; LATENCY-NEXT:  Cost Model: Found an estimated cost of 4 for instruction: %1 = load i64, i64* undef, align 4
 ; LATENCY-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %BC = bitcast i8* undef to i32*
 ; LATENCY-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %I2P = inttoptr i64 undef to i8*
-; LATENCY-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %P2I = ptrtoint i8* undef to i64
+; LATENCY-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %P2I = ptrtoint i8* undef to i64
 ; LATENCY-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %TC = trunc i64 undef to i32
 ; LATENCY-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %uadd = call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 undef, i32 undef)
 ; LATENCY-NEXT:  Cost Model: Found an estimated cost of 40 for instruction: call void undef()
@@ -29,7 +29,7 @@ define i64 @foo(i64 %arg) {
 ; CODESIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %1 = load i64, i64* undef, align 4
 ; CODESIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %BC = bitcast i8* undef to i32*
 ; CODESIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %I2P = inttoptr i64 undef to i8*
-; CODESIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %P2I = ptrtoint i8* undef to i64
+; CODESIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %P2I = ptrtoint i8* undef to i64
 ; CODESIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %TC = trunc i64 undef to i32
 ; CODESIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %uadd = call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 undef, i32 undef)
 ; CODESIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: call void undef()


### PR DESCRIPTION
This API call has been used recently with, a very valid, expectation that it would do something useful but it doesn't actually query any backend information. So, remove this method and merge its functionality into getUserCost. As well as that, also use getCastInstrCost to get a proper cost from the backend for the concerned instructions which compensates for the removal of the BasicTTI layer. The next step would be to use other useful API calls in getUserCost too.


https://reviews.llvm.org/D76124